### PR TITLE
Change filename pattern to keep extension

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -59,7 +59,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 
 		// Unique filename
 		t := time.Now()
-		name := fmt.Sprintf("%s%s-%s.%06d", extradir, handler.Filename, t.Format("20060102_150405"), rand.Intn(100000))
+		name := fmt.Sprintf("%s%s-%06d.%s", extradir, t.Format("20060102_150405"), rand.Intn(100000), handler.Filename)
 		ret := getProv().Copy(in, name)
 
 		// Send result


### PR DESCRIPTION
The file extension is used by some tools, to ease their usage, the name
pattern is modified.
 * The old pattern was
$dir$filename-$date_$time.$random6digits`
e.g. /tmp/foo.bar-20180504_142358.027887
 * the new pattern is
`'$dir-$date_$time$random6digits.$filename`
e.g. /tmp/20180504_142358-027887.foo.bar

alternative proposal:
splitting the filename in base + ext
naming like this `'$base$dir-$date_$time$random6digits.$ext`
e.g. /tmp/foo.20180504_142358-027887.bar
