### PR TITLE
Add extra tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.a
 *.dylib
 bin/
+.idea
 
 # Test binary, build with `go test -c`
 *.test

--- a/cli/command.go
+++ b/cli/command.go
@@ -33,6 +33,11 @@ func Process(appName, appDesc, appVersion string) {
 		Desc:   "Datadog app key to send notification (Env: DATADOG_APP_KEY)",
 		EnvVar: "DATADOG_APP_KEY",
 	})
+	notif.ExtraTag = app.String(cli.StringOpt{
+		Name:   "x extratag",
+		Desc:   "Datadog event extra tag (Env: EXTRA_TAG)",
+		EnvVar: "EXTRA_TAG",
+	})
 
 	app.Command("filesystem fs", "Use filesystem provider", providerFilesystem)
 	app.Command("ftp", "Use FTP provider", providerFtp)

--- a/notifier/datadog.go
+++ b/notifier/datadog.go
@@ -14,13 +14,15 @@ var (
 )
 
 type Datadog struct {
-	ApiKey, AppKey *string
+	ApiKey, AppKey, ExtraTag *string
 }
 
 func (d Datadog) Notify(event *Event) error {
 	if d.ApiKey == nil || *d.ApiKey == "" {
 		return errors.New("Cannot send event to Datadog, api key is not defined")
 	}
+
+	tags = append(tags, *d.ExtraTag)
 
 	client := datadog.NewClient(*d.ApiKey, *d.AppKey)
 	_, err := client.PostEvent(&datadog.Event{


### PR DESCRIPTION
Add an extra tag to manage datadog event routing over distributing monitor channel (ex: extraTag = 'client_env:prod')